### PR TITLE
Migrate to changed HPyModuleDef.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         git clone -b master --single-branch https://github.com/hpyproject/hpy
         cd hpy
-        git checkout 7b45ce522
+        git checkout bba7ec5f0
         pip install .
         pip install numpy cython pytest transonic pythran
 

--- a/piconumpy/_piconumpy_hpy.c
+++ b/piconumpy/_piconumpy_hpy.c
@@ -243,10 +243,9 @@ static HPyDef *module_defines[] = {
 };
 
 static HPyModuleDef piconumpymodule = {
-    HPyModuleDef_HEAD_INIT,
-    .m_name = "_piconumpy_hpy",
-    .m_doc = "piconumpy implemented with the HPy API.",
-    .m_size = -1,
+    .name = "_piconumpy_hpy",
+    .doc = "piconumpy implemented with the HPy API.",
+    .size = -1,
     .defines = module_defines,
 };
 


### PR DESCRIPTION
I've recently made an incompatible change to `HPyModuleDef` (see https://github.com/hpyproject/hpy/pull/262). This migrates piconumpy.